### PR TITLE
correct condition

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -168,7 +168,7 @@ class Query
    */
   public function setTotalStatus( int $total ): void
   {
-    if ( $total < 1 && $total > 2 )
+    if ( $total < 1 || $total > 2 )
     {
       throw new InvalidArgumentException( 'invalid total status' );
     }


### PR DESCRIPTION
The current condition will always evaluate to false because a number cannot be less than 1 and greater than 2 at the same time. It seems like you intended to use the OR operator (||) instead of AND (&&).